### PR TITLE
Support string values in `get_tables` for TestbenchData

### DIFF
--- a/uav_analysis/testbench_data.py
+++ b/uav_analysis/testbench_data.py
@@ -222,7 +222,12 @@ class TestbenchData():
 
             for field in fields:
                 if field in entry:
-                    result[field].append(float(entry[field]))
+                    try:
+                        entry_value = float(entry[field])
+                    except ValueError:
+                        entry_value = entry[field]
+
+                    result[field].append(entry_value)
                 else:
                     raise ValueError("Unknown field " + field)
 


### PR DESCRIPTION
```py
 data.get_tables(["propeller(2).motor_component_name"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\timalsu\uav-analysis\uav_analysis\testbench_data.py", line 225, in get_tables
    result[field].append(float(entry[field]))
ValueError: could not convert string to float: 't_motor_MN4012KV400'
>>> data.get_tables(["propeller(2).motor_component_name"])

```